### PR TITLE
Versioning and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM debian:jessie
+ARG VERSION=master
 
 RUN apt-get update \
   && apt-get install -y build-essential make unrar-free autoconf automake libtool gcc g++ gperf \
@@ -10,7 +11,7 @@ RUN apt-get update \
 
 RUN git clone --recursive https://github.com/pfalcon/esp-open-sdk.git \
   && git clone https://github.com/micropython/micropython.git \
-  && cd micropython && git submodule update --init \
+  && cd micropython && git checkout $VERSION && git submodule update --init \
   && chown -R micropython:micropython ../esp-open-sdk ../micropython
 
 USER micropython
@@ -20,4 +21,3 @@ RUN cd esp-open-sdk && make STANDALONE=y
 ENV PATH=/esp-open-sdk/xtensa-lx106-elf/bin:$PATH
 
 RUN cd micropython/esp8266 && make axtls && make
-

--- a/README.md
+++ b/README.md
@@ -1,8 +1,34 @@
-Attention: The binary is untested!
+Micropython on ESP8266
+======================
+The repository provides a `Dockerfile` to build the [Micropython](https://micropython.org/) firmware for [ESP8266](https://en.wikipedia.org/wiki/ESP8266) boards.
 
+***Attention***: The binary has been built and tested on OSX 10.11 running `docker-machine`
 
-build micropython in docker..
+Build Instructions
+------------------
 
-`docker build -t micropython .`
+Build the docker image. To specify a particular version of micropython provide it through the `build-args`. Otherwise the HEAD of the master branch will be used.
 
-`docker run --rm -it micropython cat /micropython/esp8266/build/firmware-combined.bin > firmware-combined.bin`
+```bash
+  docker build -t micropython --build-args VERSION=v1.8.1 .
+```
+
+Once the container is built successfuly create a container from the image
+
+```bash
+  docker create --name micropython micropython
+```
+
+Then copy the the built firmware into the host machine.
+
+```bash
+  docker cp micropython:/micropython/esp8266/build/firmware-combined.bin firmware-combined.bin
+```
+
+The firmware can then be uploaded with the esptool
+
+```bash
+  esptool.py --port ${SERIAL_PORT} --baud 115200 write_flash --verify --flash_size=8m 0 firmware-combined.bin
+```
+
+Here `${SERIAL_PORT}` is the path to the serial device on which the board is connected.


### PR DESCRIPTION
1. The current Dockerfile builds the _HEAD_ of the _master_ branch. This may not be entirely stable. I have added a build arguments using which a tag can be specified. If not specified the master branch is built.
2. The cat method to copy the files was corrupting data. I have added correct instructions to copy the built firmware.

Let me know if you have any suggestions.
